### PR TITLE
Fix bugged Â character

### DIFF
--- a/src/gui/BackgroundLayersView.js
+++ b/src/gui/BackgroundLayersView.js
@@ -89,7 +89,7 @@ define(["jquery", "underscore-min","./DynamicImageView", "./PickingManager", "./
             });
         }
 
-        function createExportSampButton() {
+        function createExportSampButton() {
             $el.find('.exportLayer').button({
                 text: false,
                 icons: {
@@ -204,7 +204,7 @@ define(["jquery", "underscore-min","./DynamicImageView", "./PickingManager", "./
             }
         }
 
-        function selectBackgroundItem() {
+        function selectBackgroundItem() {
             $el.find('#backgroundLayersSelect').iconselectmenu({
                 select: function (event, ui) {
                     var index = ui.item.index;


### PR DESCRIPTION
Â char appearing in ISO but not UTF8 breaking the javascript.
This is a known problem described by other developers [here](https://forum.sublimetext.com/t/bug-a-character-shows-up-but-invisible/7550). 

![image](https://user-images.githubusercontent.com/7287245/72060401-2eed9880-32d4-11ea-9493-7d5fb4552a36.png)

![image](https://user-images.githubusercontent.com/7287245/72060390-28f7b780-32d4-11ea-80ce-bad3a8029887.png)
