### PR TITLE
locking datacube navbar scroll when opened

### DIFF
--- a/templates/dataCube.html
+++ b/templates/dataCube.html
@@ -1,5 +1,5 @@
 
-<div id="element_body" style="background: #f1f1f1;overflow-y:scroll;height:inherit">
+<div id="element_body">
 	<div id="element" >
 			<% var appDataCube = propertiesDataCube.appDataCube; 
 			var appSpectre = propertiesDataCube.appSpectre;
@@ -19,3 +19,11 @@
 	</div>
 </div>
 <script src="templates/datacube/libs/cubeExplorer.full.min.js" ></script>
+<style>
+	#element_body {
+		background: #f1f1f1;overflow-y:scroll;height:inherit
+	}
+	html.datacube-menu #element_body {
+		overflow: hidden;
+	}
+</style>


### PR DESCRIPTION
**Warning : This would only work with DataCube [PR 29](https://github.com/MizarWeb/DataCube/pull/29) accepted**

Added this feature available in standalone DataCube :
When the navbar is opened the scrolling of the app gets disabled so that the navbar stays visible.
Not having the scrollbar showing makes it also prettier since. Without it the toggled part would cover it while the navbar wouldn't.

Here is how it looks now:
![Screenshot 2020-06-04 at 13 08 58](https://user-images.githubusercontent.com/7287245/83857125-d1426880-a71a-11ea-927c-d6499c0cae3e.png)
