### PR TITLE
Using categoryIndex property of layer to order categories.

### DIFF
--- a/src/gui/AdditionalLayersView.js
+++ b/src/gui/AdditionalLayersView.js
@@ -506,12 +506,26 @@ define(["jquery", "moment", "./AdditionalLayersCore", "./PickingManager", "./Dyn
                         $('#' + categoryId).closest(".category").show();
                     }
                 }
+                if(gwLayer.index && gwLayer.categoryIndex !== "none" ){
+                    $("h3:contains('"+category+"')").parent().data("index", gwLayer.index);
+                    sortCategories();
+
+                }
 
                 // Add HTML
                 createHtmlForAdditionalLayer(gwLayer, categoryId);
 
                 gwLayer.subscribe(mizarWidgetAPI.EVENT_MSG.LAYER_VISIBILITY_CHANGED, onVisibilityChange);
             }
+        }
+
+        function sortCategories(){
+            var $categories = $("#accordion").find(".category");
+            $categories.sort(function(a,b) {
+                aIndex = $(a).data('categoryIndex')  || "none";
+                bIndex = $(b).data('categoryIndex') || "none";
+                return aIndex > bIndex;
+           }).appendTo("#accordion");
         }
 
         /**************************************************************************************************************/


### PR DESCRIPTION
With this change using the key "categoryIndex" in one of a Category's layers will order the category. 
The index should be a number. If no categoryIndex is found "none" will be it's index.
This PR works only with another PR from MizarWeb/Mizar (see https://github.com/MizarWeb/Mizar/pull/104)